### PR TITLE
Run tests in parallel. Build prod version of app for each commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,12 @@ cache:
 install:
   - npm install
 
-script:
-  - npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-  - npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
+jobs:
+  include:
+    - stage: "Tests"
+      name: "Unit tests"
+      script: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+    - name: "E2E tests"
+      script: npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js
+    - stage: "Build prod"
+      script: npm run build


### PR DESCRIPTION
Istnieją takie błędy, które pojawiają się tylko przy budowaniu z użyciem komendy `ng build --aot --prod`. Do tej pory pojawiały się one tylko w momencie wrzuciania aplikacji na Heroku.

Z tego powodu chciałbym dodać do Travisa job, który buduje aplikację przy użyciu `ng build --aot --prod`.

Dodatkowo testy będą uruchamiać się równolegle a nie sekwencyjnie
